### PR TITLE
record.user_sid() not returning expected data

### DIFF
--- a/Evt.py
+++ b/Evt.py
@@ -100,7 +100,7 @@ class SID(Block, Nestable):
     def __len__(self):
         return self._off_sub_authorities + (self.sub_authority_count() * 4)
 
-    def string(self):
+    def __str__(self):
         ret = "S-%d-%s" % (self.revision(), self.identifier_authority())
         for sub_auth in self.sub_authorities():
             ret += "-%s" % (str(sub_auth))


### PR DESCRIPTION
with "def string(self)":
Block(buf=<mmap.mmap object at 0x0000000002F6BF30>, offset=134)

with "def __str__(self)"
S-1-0-19

Maybe I'm calling it wrong or it's a typo but noticed I wasn't getting expected SID when iterating for records and printing record.user_sid()
